### PR TITLE
Fix Stats query

### DIFF
--- a/plugins/handlers_dev.py
+++ b/plugins/handlers_dev.py
@@ -240,9 +240,9 @@ async def show_stats(client: Client, query: CallbackQuery):
 
         cmd = f"""
         grep -E '{date_string}' {log_file_path} |
-        grep -oP '\[\K[^\]]+' |
-        grep -v '^400' |
+        grep -oP '\[.*:.*:.*\]' | 
         awk -F: '{{print $NF}}' |
+        sed 's/\]$//' | \
         sort |
         uniq -c |
         sort -nr |


### PR DESCRIPTION
This used to return

     69 `The STOSC Telegram Bot was down for a few days. It is now back online ✅`

 for 2024-06. This is now fixed. Fixes #35